### PR TITLE
Feature/add reset function

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 
 class encoderRecipe(ConanFile):
     name = "encoder-to-odom"
-    version = "1.0.0"
+    version = "1.0.1"
     package_type = "library"
 
     license = "Apache 2.0"

--- a/include/odometry.h
+++ b/include/odometry.h
@@ -112,6 +112,30 @@ class OdometryProcessor
     void reset();
 
     /**
+     * @brief Reset the distance values to zero
+     *
+     */
+    void resetDistance();
+
+    /**
+     * @brief Reset the position values to zero
+     *
+     */
+    void resetPosition();
+
+    /**
+     * @brief Reset the total degrees traveled by both motors to zero
+     *
+     */
+    void resetTotalDegreesTraveled();
+
+    /**
+     * @brief Reset the total meters traveled by both motors to zero
+     *
+     */
+    void resetTotalMetersTraveled();
+
+    /**
      * @brief Get the Position object
      *
      * @return Position (x,y,theta) or robot in odom coordinate frame
@@ -293,10 +317,10 @@ class OdometryProcessor
     /// Mappings for each motors individual recorded values
     std::map<Motor, float> currentReadings;
     std::map<Motor, float> lastReadings;
+    std::map<Motor, float> degreesTraveledInFrame;
     std::map<Motor, float> totalDegreesTraveled;
     std::map<Motor, float> metersTraveledInFrame;
     std::map<Motor, float> totalMetersTraveled;
-    std::map<Motor, float> degreesTraveledInFrame;
 
     /// Number of readings to throw out before considering the system stabilized
     int stabilizationAmount = SETTLE_READINGS;

--- a/include/odometry.h
+++ b/include/odometry.h
@@ -293,7 +293,7 @@ class OdometryProcessor
     std::map<Motor, float> degreesTraveledInFrame;
 
     /// Number of readings to throw out before considering the system stabilized
-    int stablizationAmount = SETTLE_READINGS;
+    int stabilizationAmount = SETTLE_READINGS;
 
     /// Which direction positive change in encoder values should be expected
     bool rightIncrease;

--- a/include/odometry.h
+++ b/include/odometry.h
@@ -106,6 +106,12 @@ class OdometryProcessor
     void processData();
 
     /**
+     * @brief Reset the odometry processor to initial state
+     *
+     */
+    void reset();
+
+    /**
      * @brief Get the Position object
      *
      * @return Position (x,y,theta) or robot in odom coordinate frame

--- a/src/odometry.cpp
+++ b/src/odometry.cpp
@@ -187,21 +187,14 @@ void OdometryProcessor::reset()
     this->lastReadings[Motor::LEFT] = 0.0;
     this->lastReadings[Motor::RIGHT] = 0.0;
 
-    this->totalDegreesTraveled[Motor::LEFT] = 0.0;
-    this->totalDegreesTraveled[Motor::RIGHT] = 0.0;
-
-    this->metersTraveledInFrame[Motor::LEFT] = 0.0;
-    this->metersTraveledInFrame[Motor::RIGHT] = 0.0;
-
-    this->distance.frameDistance = 0.0;
-    this->distance.totalDistance = 0.0;
-
     this->velocity.linearX = 0.0;
     this->velocity.angularZ = 0.0;
 
-    this->currentPosition.x = 0.0;
-    this->currentPosition.y = 0.0;
-    this->currentPosition.theta = 0.0;
+    this->resetTotalDegreesTraveled();
+    this->resetTotalMetersTraveled();
+
+    this->resetDistance();
+    this->resetPosition();
 
     // Reset timestamp and delta time
     this->timestamp = 0;
@@ -209,6 +202,31 @@ void OdometryProcessor::reset()
 
     // Reset the stabilization counter
     this->stabilizationAmount = SETTLE_READINGS;
+}
+
+void OdometryProcessor::resetDistance()
+{
+    this->distance.frameDistance = 0.0;
+    this->distance.totalDistance = 0.0;
+}
+
+void OdometryProcessor::resetPosition()
+{
+    this->currentPosition.x = 0.0;
+    this->currentPosition.y = 0.0;
+    this->currentPosition.theta = 0.0;
+}
+
+void OdometryProcessor::resetTotalDegreesTraveled()
+{
+    this->totalDegreesTraveled[Motor::LEFT] = 0.0;
+    this->totalDegreesTraveled[Motor::RIGHT] = 0.0;
+}
+
+void OdometryProcessor::resetTotalMetersTraveled()
+{
+    this->totalMetersTraveled[Motor::LEFT] = 0.0;
+    this->totalMetersTraveled[Motor::RIGHT] = 0.0;
 }
 
 // Getters

--- a/src/odometry.cpp
+++ b/src/odometry.cpp
@@ -178,6 +178,39 @@ void OdometryProcessor::processData()
     }
 }
 
+void OdometryProcessor::reset()
+{
+    // Reset all readings
+    this->currentReadings[Motor::LEFT] = 0.0;
+    this->currentReadings[Motor::RIGHT] = 0.0;
+
+    this->lastReadings[Motor::LEFT] = 0.0;
+    this->lastReadings[Motor::RIGHT] = 0.0;
+
+    this->totalDegreesTraveled[Motor::LEFT] = 0.0;
+    this->totalDegreesTraveled[Motor::RIGHT] = 0.0;
+
+    this->metersTraveledInFrame[Motor::LEFT] = 0.0;
+    this->metersTraveledInFrame[Motor::RIGHT] = 0.0;
+
+    this->distance.frameDistance = 0.0;
+    this->distance.totalDistance = 0.0;
+
+    this->velocity.linearX = 0.0;
+    this->velocity.angularZ = 0.0;
+
+    this->currentPosition.x = 0.0;
+    this->currentPosition.y = 0.0;
+    this->currentPosition.theta = 0.0;
+
+    // Reset timestamp and delta time
+    this->timestamp = 0;
+    this->deltaTime = 0;
+
+    // Reset the stabilization counter
+    this->stabilizationAmount = SETTLE_READINGS;
+}
+
 // Getters
 float OdometryProcessor::getCurrentReading(Motor motor) { return this->currentReadings[motor]; }
 

--- a/src/odometry.cpp
+++ b/src/odometry.cpp
@@ -38,9 +38,9 @@ void OdometryProcessor::updateTimestamp(uint16_t timestamp)
 
 bool OdometryProcessor::settled()
 {
-    if (this->stablizationAmount > 0)
+    if (this->stabilizationAmount > 0)
     {
-        this->stablizationAmount--;
+        this->stabilizationAmount--;
         return false;
     }
     return true;


### PR DESCRIPTION
Add reset functionality for the following example use case:
 - Encoder data was being processed, encoder data has stopped being received for a period of time, encoder data being received has been resumed